### PR TITLE
feat: task-7 basic lambda authorizer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ node_modules
 # CDK asset staging directory
 .cdk.staging
 cdk.out
+.env

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 !jest.config.js
 !product-service/lambda/*.js
 !import-service/lambda/*.js
+!authorization-service/lambda/*.js
 *.d.ts
 node_modules
 .idea

--- a/authorization-service/lambda/basicAuthorizer.js
+++ b/authorization-service/lambda/basicAuthorizer.js
@@ -1,0 +1,67 @@
+// require('dotenv').config();
+// const dotenv = require('dotenv');
+
+exports.handler = async (event, context) => {
+    console.log('!@# Basic Authorizer event: ', event);
+    try {
+        const authorizationToken = event.headers.Authorization;
+        if (!authorizationToken) {
+            return {
+                statusCode: 401,
+                body: JSON.stringify({ message: 'Authorization header is missing' }),
+            };
+        }
+        const [type, credentials] = authorizationToken.split(' ');
+
+        if (type !== 'Basic' || !credentials) {
+            return {
+                statusCode: 403,
+                body: JSON.stringify({ message: 'Invalid authorization type or missing credentials' }),
+            };
+        }
+
+        const decodedCredentials = Buffer.from(credentials, 'base64').toString('utf-8');
+        const [username, password] = decodedCredentials.split(':');
+        console.log('username: ', username);
+        console.log('password: ', password);
+        // const expectedPassword = process.env[username];
+        const expectedPassword = 'TEST-PASSWORD';
+        console.log('expectedPassword: ', expectedPassword);
+        //
+        if (expectedPassword === password) {
+            const policy = generatePolicy('user', 'Allow', event.methodArn);
+            console.log('!!!!!!!', policy);
+            return policy;
+        } else {
+            return {
+                statusCode: 403,
+                body: JSON.stringify({ message: 'Access denied MOTHERFUCKER!!!!' }),
+            };
+        }
+    } catch (error) {
+        console.log('Error: ', error);
+        return {
+            statusCode: 403,
+            body: JSON.stringify({ message: 'Access denied END!!!' }),
+        };
+    }
+}
+
+const generatePolicy = (principalId, effect, resource) => {
+    const policyDocument = {
+        Version: '2012-10-17',
+        Statement: [
+            {
+                Action: 'execute-api:Invoke',
+                Effect: effect,
+                Resource: resource,
+            },
+        ],
+    };
+
+    return {
+        principalId,
+        policyDocument,
+    };
+};
+

--- a/authorization-service/lambda/basicAuthorizer.js
+++ b/authorization-service/lambda/basicAuthorizer.js
@@ -1,5 +1,4 @@
-// require('dotenv').config();
-// const dotenv = require('dotenv');
+const dotenv = require('dotenv');
 
 exports.handler = async (event, context) => {
     console.log('!@# Basic Authorizer event: ', event);
@@ -24,8 +23,7 @@ exports.handler = async (event, context) => {
         const [username, password] = decodedCredentials.split(':');
         console.log('username: ', username);
         console.log('password: ', password);
-        // const expectedPassword = process.env[username];
-        const expectedPassword = 'TEST-PASSWORD';
+        const expectedPassword = process.env.PASSWORD;
         console.log('expectedPassword: ', expectedPassword);
         //
         if (expectedPassword === password) {

--- a/authorization-service/lambda/basicAuthorizer.js
+++ b/authorization-service/lambda/basicAuthorizer.js
@@ -35,7 +35,7 @@ exports.handler = async (event, context) => {
         } else {
             return {
                 statusCode: 403,
-                body: JSON.stringify({ message: 'Access denied MOTHERFUCKER!!!!' }),
+                body: JSON.stringify({ message: 'Access denied' }),
             };
         }
     } catch (error) {

--- a/lib/aws-shop-backend-stack.ts
+++ b/lib/aws-shop-backend-stack.ts
@@ -10,7 +10,8 @@ import * as events_sources from 'aws-cdk-lib/aws-lambda-event-sources';
 import * as sns from 'aws-cdk-lib/aws-sns';
 import * as sns_subscriptions from 'aws-cdk-lib/aws-sns-subscriptions';
 import * as dynamodb from 'aws-cdk-lib/aws-dynamodb';
-import 'dotenv/config';
+import { config } from "dotenv";
+config();
 
 export class AwsShopBackendStack extends cdk.Stack {
   constructor(scope: Construct, id: string, props?: cdk.StackProps) {
@@ -163,8 +164,8 @@ export class AwsShopBackendStack extends cdk.Stack {
         handler: 'basicAuthorizer.handler',
         code: lambda.Code.fromAsset('authorization-service/lambda'),
         environment: {
-            LOGIN_PASSWORD: 'pavel-sobchenko=TEST_PASSWORD',
-            // LOGIN_PASSWORD: process.env.LOGIN=process.env.TEST_PASSWORD,
+            LOGIN: process.env.LOGIN!,
+            PASSWORD: process.env.PASSWORD!,
         }
     });
 

--- a/lib/aws-shop-backend-stack.ts
+++ b/lib/aws-shop-backend-stack.ts
@@ -168,10 +168,10 @@ export class AwsShopBackendStack extends cdk.Stack {
         }
     });
 
-    // const authorizer = new apigateway.TokenAuthorizer(this, 'BasicAuthorizer', {
-    //     handler: basicAuthorizerLambda,
-    //     identitySource: 'method.request.header.Authorization',
-    // });
+    const authorizer = new apigateway.TokenAuthorizer(this, 'BasicAuthorizer', {
+        handler: basicAuthorizerLambda,
+        identitySource: 'method.request.header.Authorization',
+    });
 
     /***End of autorization service lambda functions*******/
 
@@ -193,25 +193,25 @@ export class AwsShopBackendStack extends cdk.Stack {
     productIdResource.addMethod('GET', new apigateway.LambdaIntegration(getProductsByIdLambda));
 
     const importResource = api.root.addResource('import',
-        // {
-        //     defaultMethodOptions: {
-        //         authorizer
-        //     }
-        // }
+        {
+            defaultMethodOptions: {
+                methodResponses: [{
+                    statusCode: '200',
+                    responseParameters: {
+                        'method.response.header.Content-Type': true,
+                        'method.response.header.Access-Control-Allow-Origin': true,
+                    },
+                }],
+                authorizationType: apigateway.AuthorizationType.CUSTOM,
+                authorizer
+            }
+        }
         );
     importResource.addMethod('GET', new apigateway.LambdaIntegration(importProductsFileLambda));
 
     importProductsFileLambda.addPermission('ApiGatewayInvokePermission',{
         principal: new iam.ServicePrincipal('apigateway.amazonaws.com'),
     });
-
-    // const secureEndpoint = api.root.addResource('secure');
-    // secureEndpoint.addMethod('GET', new apigateway.HttpIntegration('http:/localhost:3000'), {
-    //     authorizationType: apigateway.AuthorizationType.CUSTOM,
-    //     authorizer: {
-    //         authorizerId: authorizer.authorizerId,
-    //     }
-    // });
 
     const emailSubscriptionWithFilterPolicy = new sns_subscriptions.EmailSubscription(
       'email@example.com',

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "aws-sdk-mock": "^5.8.0",
     "constructs": "^10.0.0",
     "csv-parser": "^3.0.0",
+    "dotenv": "^16.3.1",
     "source-map-support": "^0.5.21"
   }
 }


### PR DESCRIPTION
FE PR: https://github.com/pavel-sobchenko/nodejs-aws-shop-react/pull/4
FE deployed: https://dhon86jwquapr.cloudfront.net/

Task 7.1
Create a new service called authorization-service at the same level as Product and Import services with its own AWS CDK Stack. 
Create a lambda function called basicAuthorizer under the Authorization Service.
This basicAuthorizer lambda should take Basic Authorization token, decode it and check that credentials provided by token exist in the lambda environment variable.
This lambda should return 403 HTTP status if access is denied for this user (invalid authorization_token) and 401 HTTP status if Authorization header is not provided.
Task 7.2
Add Lambda authorization to the /import path of the Import Service API Gateway.
Use your basicAuthorizer lambda as the Lambda authorizer
Task 7.3
Request from the client application to the /import path of the Import Service should have Basic Authorization header:
  Authorization: Basic {authorization_token}

+30 - Client application should display alerts for the responses in 401 and 403 HTTP statuses. This behavior should be added to the nodejs-aws-fe-main/src/index.tsx file.

Self-evaluation: 100/100
